### PR TITLE
Allow revdate artifact to be overwritten

### DIFF
--- a/.github/actions/check-revdate-composite-action/action.yml
+++ b/.github/actions/check-revdate-composite-action/action.yml
@@ -36,4 +36,5 @@ runs:
       with:
         name: comment-artifact
         path: comment-artifact
+        overwrite: true
       


### PR DESCRIPTION
Our rancher-product-docs recently started [changed our workflow jobs](https://github.com/rancher/rancher-product-docs/pull/783) to use a matrix strategy and it the current revdate action fails because the artifact exists on the workflow run already (e.g. https://github.com/rancher/rancher-product-docs/actions/runs/22366233219/job/64732866927). 

This PR is a short term change to attempt to unblock CI. A proper solution will be looked at a later time.