### PR TITLE
Fix revdate action

### DIFF
--- a/.github/actions/check-revdate-composite-action/action.yml
+++ b/.github/actions/check-revdate-composite-action/action.yml
@@ -12,7 +12,8 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.token }}
       run: |
-        result=$(helpers/scripts/recurring/check_revdate ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }})
+        ancestor=$(git merge-base main ${{ github.head_ref }})
+        result=$(helpers/scripts/recurring/check_revdate $ancestor ${{ github.event.pull_request.head.sha }})
         if [[ -n "$result" ]]; then
           mkdir comment-artifact
           echo "As of ${{ github.event.pull_request.head.sha }}, the following files have been modified without a corresponding update to the \`revdate\` page attribute. If this is intentional, please ignore this message. 

--- a/.github/workflows/test-deploy-min.yml
+++ b/.github/workflows/test-deploy-min.yml
@@ -24,7 +24,7 @@ jobs:
           submodules: recursive
 
       - name: Checkout helper scripts
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@bef76c9aab79980088a221e72e006acd3bfd8257 # v4
         with:
           repository: rancher/product-docs-common
           ref: main
@@ -38,7 +38,7 @@ jobs:
           node-version: 22
 
       - name: Check revdate
-        uses: rancher/product-docs-common/.github/actions/check-revdate-composite-action@e37ee6abff600fe8b90fa8d6ad41ec23d9c4b90c # main
+        uses: rancher/product-docs-common/.github/actions/check-revdate-composite-action@bef76c9aab79980088a221e72e006acd3bfd8257 # main
         with:
           token: ${{ secrets.token }}
 


### PR DESCRIPTION
Use common ancestor to identify modified files
    
Currently, files that aren't part of the feature branch are flagged as modified when upstream's main is used as the basis of comparison and the feature branch is behind upstream's main.