### PR TITLE
Add script and action to check for broken symlinks

### DIFF
--- a/.github/actions/check-symlinks-composite-action/action.yml
+++ b/.github/actions/check-symlinks-composite-action/action.yml
@@ -1,0 +1,9 @@
+name: 'Check for broken symlinks'
+description: 'Checks for broken symlinks in the repository.'
+runs:
+  using: 'composite'
+  steps:
+    - name: Check for broken symlinks
+      id: check-symlinks
+      run: ./helpers/scripts/recurring/check_symlinks
+      shell: bash      

--- a/.github/workflows/test-deploy-min.yml
+++ b/.github/workflows/test-deploy-min.yml
@@ -36,14 +36,17 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
-
+      
       - name: Check revdate
-        uses: rancher/product-docs-common/.github/actions/check-revdate-composite-action@bef76c9aab79980088a221e72e006acd3bfd8257 # main
+        uses: rancher/product-docs-common/.github/actions/check-revdate-composite-action@bef76c9aab79980088a221e72e006acd3bfd8257
         with:
           token: ${{ secrets.token }}
 
       - name: Install Antora and dependencies
         run: make environment
+
+      - name: Check for broken symlinks
+        uses: rancher/product-docs-common/.github/actions/check-symlinks-composite-action@6da2db6b0b9d098f1cd540aa6e076865365497a4
 
       - name: Generate Site
         run: |

--- a/scripts/recurring/check_symlinks
+++ b/scripts/recurring/check_symlinks
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+# 
+# Checks for broken symlinks in a given directory. If a directory is not
+# provided, it defaults to the current directory.
+#
+# $1 is a directory to check for broken symlinks.
+# 
+# So, for example, invoke as
+# 
+# scripts/recurring/check_symlinks
+#
+# scripts/recurring/check_symlinks <directory>
+#
+
+TARGET_DIR="${1:-.}"
+
+if [ ! -d "$TARGET_DIR" ]; then
+    echo "Error: '$TARGET_DIR' is not a valid directory." >&2
+    exit 2
+fi
+
+echo "Searching for broken symlinks in: $TARGET_DIR"
+echo "---------------------------------------------------"
+
+# Create a temporary file to store the count
+tmp_file=$(mktemp)
+echo 0 > "$tmp_file"
+
+# POSIX compliant find and loop
+find "$TARGET_DIR" -xtype l 2>/dev/null | while read -r symlink; do
+    if [ -n "$symlink" ]; then
+        target=$(readlink "$symlink")
+        echo "Broken: '$symlink' -> (Points to non-existent: '$target')"
+        
+        # Increment the counter inside the file
+        count=$(cat "$tmp_file")
+        echo $((count + 1)) > "$tmp_file"
+    fi
+done
+
+# Read the final count back
+broken_count=$(cat "$tmp_file")
+rm -f "$tmp_file" # Clean up temp file
+
+echo "---------------------------------------------------"
+
+if [ "$broken_count" -gt 0 ]; then
+    echo "Error: Found $broken_count broken symbolic link(s)!" >&2
+    exit 1
+else
+    echo "Success: No broken symlinks found."
+    exit 0
+fi


### PR DESCRIPTION
Broken symlinks are one of the few errors that can lead to our builds on product-docs-playbook breaking.

This PR:
- Adds a script that can be ran locally and outputs a list of broken symlinks.
- Adds a composite action that be used in workflows.
  - The composite action calls the script which generates exit code 1 to fail the action/workflow if broken symlinks are present.
- Updates the test-deploy-min reusable workflow to call the new action. 

Note that using this action is not needed in cases where Antora (or the workflow) is configured to fail if an Antora build produces log entries any `ERROR` level logs, which is what broken symlinks are classified as.

These are test runs done on my fork (where the workflow files point to forked version/pinned commits):
- A [commit](https://github.com/btat/rancher-product-docs/pull/27/changes/8878f1a8b41495cf02a5b20ac3076be043bd156c) adding a working symlink where CI passes
- A [commit](https://github.com/btat/rancher-product-docs/pull/27/changes/72ff68947619b781af76bf024c76f27a0dbcacfa) adding a broken symlink where CI fails