### PR TITLE
Add tag so dependabot stops tracking the main branch

### DIFF
--- a/.github/workflows/test-deploy-min.yml
+++ b/.github/workflows/test-deploy-min.yml
@@ -38,7 +38,7 @@ jobs:
           node-version: 22
       
       - name: Check revdate
-        uses: rancher/product-docs-common/.github/actions/check-revdate-composite-action@776dee012d9ab2f661cdbdeeb16e6ab81e965d5a
+        uses: rancher/product-docs-common/.github/actions/check-revdate-composite-action@776dee012d9ab2f661cdbdeeb16e6ab81e965d5a # v1.0.0
         with:
           token: ${{ secrets.token }}
 
@@ -46,7 +46,7 @@ jobs:
         run: make environment
 
       - name: Check for broken symlinks
-        uses: rancher/product-docs-common/.github/actions/check-symlinks-composite-action@776dee012d9ab2f661cdbdeeb16e6ab81e965d5a
+        uses: rancher/product-docs-common/.github/actions/check-symlinks-composite-action@776dee012d9ab2f661cdbdeeb16e6ab81e965d5a # v1.0.0
 
       - name: Generate Site
         run: |


### PR DESCRIPTION
Without the tag comment, dependabot tracks the main branch instead and generates a new PR to bump the pinned SHAs. Merging these will cause main to be updated and dependabot to bump the pinned SHAs thus creating a perpetual cycle.

E.g. After merging #79 and #80 they created a new commit on main, which then requires via #83 and #84. Merging #83 and #84 would create another set of bumps.